### PR TITLE
Added a CMake file to easily build citybuilder and link it against SFML.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(citybuilder)
+
+# Set options
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
+set(SFML_STATIC_LIBS FALSE CACHE BOOL "Choose whether SFML is linked statically or shared.")
+set(CITYBUILDER_STATIC_STD_LIBS FALSE CACHE BOOL "Use statically linked standard/runtime libraries? This option must match the one used for SFML.")
+
+# Make sure that the runtime library gets link statically
+if(CITYBUILDER_STATIC_STD_LIBS)
+	if(NOT SFML_STATIC_LIBS)
+		message("\n-> If you check CITYBUILDER_STATIC_STD_LIBS, you also need to check SFML_STATIC_LIBRARIES.")
+		message("-> It would lead to multiple runtime environments which result in undefined behavior.\n")
+	elseif(WIN32 AND MSVC)
+		# Change all MSVC compiler flags to /MT
+		foreach(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE)
+			if(${flag} MATCHES "/MD")
+			string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+			endif()
+		endforeach()
+	elseif(CMAKE_COMPILER_IS_GNUCXX)
+		# Note: Doesn't work for TDM compiler, since it's compiling the runtime libs statically by default
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+	endif()
+endif()
+
+# citybuilder uses C++11 features
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+# Add directory containing FindSFML.cmake to module path
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/;${CMAKE_MODULE_PATH}")
+
+# Make sure that FindSFML.cmake searches for the static libraries
+if(SFML_STATIC_LIBS)
+	set(SFML_STATIC_LIBRARIES TRUE)
+endif()
+
+# Find SFML
+find_package(SFML 2 COMPONENTS graphics window system)
+
+# Output an error if SFML wasn't found
+if(SFML_FOUND)
+	include_directories(${SFML_INCLUDE_DIR})
+else()
+	set(SFML_ROOT "" CACHE PATH "SFML top-level directory")
+	message("\n-> SFML directory not found. Set SFML_ROOT to SFML's top-level path (containing \"include\" and \"lib\" directories).")
+	message("-> Make sure the SFML libraries with the same configuration (Release/Debug, Static/Dynamic) exist.\n")
+endif()
+
+# Add the source files
+file(GLOB CITYBUILDER_SRC
+	"*.h"
+	"*.cpp"
+)
+
+# Tell CMake to build a executable
+add_executable(citybuilder ${CITYBUILDER_SRC})
+
+# Link SFML
+target_link_libraries(citybuilder ${SFML_LIBRARIES} ${SFML_DEPENDENCIES})
+
+# Install executable
+install(TARGETS citybuilder
+		RUNTIME DESTINATION .)
+
+# Install game assets
+install(DIRECTORY media/
+		DESTINATION media/)
+		
+# Install config files
+install(FILES city_cfg.dat city_map.dat LICENSE README.md
+		DESTINATION .)


### PR DESCRIPTION
With the added `CMakeLists.txt` it should be rather easy to build _citybuilder_ and link it against the SFML libraries.
Here's basically what you need to do:
- [Optional] Set `CMAKE_BUILD_TYPE` to either `Release` or `Debug` depending which type you want to build for.
- [Optional] Check `SFML_STATIC_LIBS` if you want to link SFML statically.
- [Optional] Check `CITYBUILDER_STATIC_STD_LIBS` if you want to link the runtime libraries static. **Note:** SFML needs to be linked with the same option.
- [Optional] Set `CMAKE_INSTALL_PREFIX` to the directory you want _citybuilder_ to get installed to.
- Set `CMAKE_MODULE_PATH` to SFML's directory `SFML/cmake/Modules` or install the `FindSFML.cmake` in your shared CMake directory.
- Set `SFML_ROOT` to the directory SFML can be found in.
- Generate a make or project file and use that to build _citybuilder_.
